### PR TITLE
DM-35216: Added the standalone tests for the MTAirCompressor. Eventually, these…

### DIFF
--- a/python/lsst/ts/IntegrationTests/configs/eas_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/eas_state_transition_configs.py
@@ -31,6 +31,7 @@ yaml_string = yaml.safe_load(
     """
     data:
     - [DIMM:1, DISABLED]
+    - [DIMM:2, DISABLED]
     - [WeatherStation:1, DISABLED]
     """
 )
@@ -44,6 +45,7 @@ yaml_string = yaml.safe_load(
     """
     data:
     - [DIMM:1, ENABLED]
+    - [DIMM:2, ENABLED]
     - [WeatherStation:1, ENABLED]
     """
 )

--- a/python/lsst/ts/IntegrationTests/configs/enabled_offline_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/enabled_offline_state_transition_configs.py
@@ -48,6 +48,7 @@ yaml_string = yaml.safe_load(
     - [DSM:2, OFFLINE]
     - [DSM:1, OFFLINE]
     - [DIMM:1, OFFLINE]
+    - [DIMM:2, OFFLINE]
     - [WeatherStation:1, OFFLINE]
     """
 )

--- a/python/lsst/ts/IntegrationTests/configs/enabled_offline_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/enabled_offline_state_transition_configs.py
@@ -69,3 +69,15 @@ yaml_string = yaml.safe_load(
 registry["watcher_sq_enabled_offline"] = yaml.safe_dump(
     yaml_string, explicit_start=True, canonical=True
 )
+
+# MTAirCompressor enabled_offline
+yaml_string = yaml.safe_load(
+    """
+    data:
+    - [MTAirCompressor, OFFLINE]
+    """
+)
+
+registry["mt_air_enabled_offline"] = yaml.safe_dump(
+    yaml_string, explicit_start=True, canonical=True
+)

--- a/python/lsst/ts/IntegrationTests/configs/enabled_offline_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/enabled_offline_state_transition_configs.py
@@ -75,10 +75,11 @@ registry["watcher_sq_enabled_offline"] = yaml.safe_dump(
 yaml_string = yaml.safe_load(
     """
     data:
-    - [MTAirCompressor, OFFLINE]
+    - [MTAirCompressor:1, OFFLINE]
+    - [MTAirCompressor:2, OFFLINE]
     """
 )
 
-registry["mt_air_enabled_offline"] = yaml.safe_dump(
+registry["mtaircomp_enabled_offline"] = yaml.safe_dump(
     yaml_string, explicit_start=True, canonical=True
 )

--- a/python/lsst/ts/IntegrationTests/configs/maintel_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/maintel_state_transition_configs.py
@@ -107,3 +107,26 @@ yaml_string = yaml.safe_load(
 registry["maintel_camera_disabled_enabled"] = yaml.safe_dump(
     yaml_string, explicit_start=True, canonical=True
 )
+
+# MT AirCompressor configs (separate for now)
+yaml_string = yaml.safe_load(
+    """
+    data:
+    - [MTAirCompressor, DISABLED]
+    """
+)
+
+registry["mt_air_standby_disabled"] = yaml.safe_dump(
+    yaml_string, explicit_start=True, canonical=True
+)
+
+yaml_string = yaml.safe_load(
+    """
+    data:
+    - [MTAirCompressor, ENABLED]
+    """
+)
+
+registry["mt_air_disabled_enabled"] = yaml.safe_dump(
+    yaml_string, explicit_start=True, canonical=True
+)

--- a/python/lsst/ts/IntegrationTests/configs/maintel_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/maintel_state_transition_configs.py
@@ -112,21 +112,23 @@ registry["maintel_camera_disabled_enabled"] = yaml.safe_dump(
 yaml_string = yaml.safe_load(
     """
     data:
-    - [MTAirCompressor, DISABLED]
+    - [MTAirCompressor:1, DISABLED]
+    - [MTAirCompressor:2, DISABLED]
     """
 )
 
-registry["mt_air_standby_disabled"] = yaml.safe_dump(
+registry["mtaircomp_standby_disabled"] = yaml.safe_dump(
     yaml_string, explicit_start=True, canonical=True
 )
 
 yaml_string = yaml.safe_load(
     """
     data:
-    - [MTAirCompressor, ENABLED]
+    - [MTAirCompressor:1, ENABLED]
+    - [MTAirCompressor:2, ENABLED]
     """
 )
 
-registry["mt_air_disabled_enabled"] = yaml.safe_dump(
+registry["mtaircomp_disabled_enabled"] = yaml.safe_dump(
     yaml_string, explicit_start=True, canonical=True
 )

--- a/python/lsst/ts/IntegrationTests/configs/maintel_state_transition_configs.py
+++ b/python/lsst/ts/IntegrationTests/configs/maintel_state_transition_configs.py
@@ -112,18 +112,6 @@ registry["maintel_camera_disabled_enabled"] = yaml.safe_dump(
 yaml_string = yaml.safe_load(
     """
     data:
-    - [MTAirCompressor:1, DISABLED]
-    - [MTAirCompressor:2, DISABLED]
-    """
-)
-
-registry["mtaircomp_standby_disabled"] = yaml.safe_dump(
-    yaml_string, explicit_start=True, canonical=True
-)
-
-yaml_string = yaml.safe_load(
-    """
-    data:
     - [MTAirCompressor:1, ENABLED]
     - [MTAirCompressor:2, ENABLED]
     """

--- a/python/lsst/ts/IntegrationTests/enabled_offline.py
+++ b/python/lsst/ts/IntegrationTests/enabled_offline.py
@@ -41,7 +41,7 @@ class EnabledOffline(BaseScript):
         [],
         registry["eas_enabled_offline"],
         registry["watcher_sq_enabled_offline"],
-        registry["mt_air_enabled_offline"],
+        registry["mtaircomp_enabled_offline"],
     )
     scripts: list = [
         ("set_summary_state.py", BaseScript.is_standard),

--- a/python/lsst/ts/IntegrationTests/enabled_offline.py
+++ b/python/lsst/ts/IntegrationTests/enabled_offline.py
@@ -41,6 +41,7 @@ class EnabledOffline(BaseScript):
         [],
         registry["eas_enabled_offline"],
         registry["watcher_sq_enabled_offline"],
+        registry["mt_air_enabled_offline"],
     )
     scripts: list = [
         ("set_summary_state.py", BaseScript.is_standard),
@@ -48,6 +49,7 @@ class EnabledOffline(BaseScript):
         ("auxtel/offline_latiss.py", BaseScript.is_standard),
         ("maintel/offline_mtcs.py", BaseScript.is_standard),
         ("maintel/offline_comcam.py", BaseScript.is_standard),
+        ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
     ]

--- a/python/lsst/ts/IntegrationTests/maintel_disabled_enabled.py
+++ b/python/lsst/ts/IntegrationTests/maintel_disabled_enabled.py
@@ -35,7 +35,7 @@ class MainTelDisabledEnabled(BaseScript):
     index: int = 1
     configs: tuple = (
         registry["maintel_disabled_enabled"],
-        registry["mt_air_disabled_enabled"],
+        registry["mtaircomp_disabled_enabled"],
         registry["maintel_camera_disabled_enabled"],
     )
     scripts: list = [

--- a/python/lsst/ts/IntegrationTests/maintel_disabled_enabled.py
+++ b/python/lsst/ts/IntegrationTests/maintel_disabled_enabled.py
@@ -35,9 +35,11 @@ class MainTelDisabledEnabled(BaseScript):
     index: int = 1
     configs: tuple = (
         registry["maintel_disabled_enabled"],
+        registry["mt_air_disabled_enabled"],
         registry["maintel_camera_disabled_enabled"],
     )
     scripts: list = [
+        ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
     ]

--- a/python/lsst/ts/IntegrationTests/maintel_standby_disabled.py
+++ b/python/lsst/ts/IntegrationTests/maintel_standby_disabled.py
@@ -35,9 +35,11 @@ class MainTelStandbyDisabled(BaseScript):
     index: int = 1
     configs: tuple = (
         registry["maintel_standby_disabled"],
+        registry["mt_air_standby_disabled"],
         registry["maintel_camera_standby_disabled"],
     )
     scripts: list = [
+        ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
     ]

--- a/python/lsst/ts/IntegrationTests/maintel_standby_disabled.py
+++ b/python/lsst/ts/IntegrationTests/maintel_standby_disabled.py
@@ -35,7 +35,7 @@ class MainTelStandbyDisabled(BaseScript):
     index: int = 1
     configs: tuple = (
         registry["maintel_standby_disabled"],
-        registry["mt_air_standby_disabled"],
+        registry["mtaircomp_standby_disabled"],
         registry["maintel_camera_standby_disabled"],
     )
     scripts: list = [

--- a/python/lsst/ts/IntegrationTests/maintel_standby_disabled.py
+++ b/python/lsst/ts/IntegrationTests/maintel_standby_disabled.py
@@ -35,11 +35,9 @@ class MainTelStandbyDisabled(BaseScript):
     index: int = 1
     configs: tuple = (
         registry["maintel_standby_disabled"],
-        registry["mtaircomp_standby_disabled"],
         registry["maintel_camera_standby_disabled"],
     )
     scripts: list = [
-        ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
         ("set_summary_state.py", BaseScript.is_standard),
     ]


### PR DESCRIPTION
… will be merged with the MainTel tests and won't require separate configs and script calls.