### PR TITLE
Tickets/dm38921: Properly handle the FAILED state

### DIFF
--- a/python/lsst/ts/IntegrationTests/__init__.py
+++ b/python/lsst/ts/IntegrationTests/__init__.py
@@ -58,3 +58,4 @@ from .enabled_offline import *
 from .load_camera_playlist import *
 from .love_stress_test import *
 from .script_queue_controller import *
+from .failing_script_queue_controller import *

--- a/python/lsst/ts/IntegrationTests/base_script.py
+++ b/python/lsst/ts/IntegrationTests/base_script.py
@@ -57,6 +57,10 @@ class BaseScript:
         A list of tuples. The tuple is the script name and a boolean.
         The boolean specifies the script as Standard (True)
         or External (False).
+    processing_states : `frozenset`
+        An immutable set of the ScriptQueue processing states.
+    terminal_states : `frozenset`
+        An immutable set of the ScriptQueue terminal states.
     """
 
     # See Attributes for the definition.
@@ -112,11 +116,11 @@ class BaseScript:
             A simple boolean variable, defaulting to False, that is set to
             True once all the scripts are complete.
         """
+        self.remote: salobj.Remote
         self.queue_placement: str = queue_placement
         self.script_states: list[int] = []
         self.temp_script_indexes: list[int] = []
         self.all_scripts_done: bool = False
-        self.remote: salobj.Remote
 
     @classmethod
     def get_current_date(cls, date_format: str = "%Y-%m-%d") -> str:

--- a/python/lsst/ts/IntegrationTests/base_script.py
+++ b/python/lsst/ts/IntegrationTests/base_script.py
@@ -23,7 +23,7 @@ __all__ = ["BaseScript"]
 import asyncio
 import copy
 from lsst.ts import salobj
-from lsst.ts.idl.enums import Script
+from lsst.ts.idl.enums import Script, ScriptQueue
 from lsst.ts.idl.enums.ScriptQueue import Location, ScriptProcessState
 from datetime import date
 
@@ -183,7 +183,7 @@ class BaseScript:
             # NOTE: This MUST be done LAST. Otherwise, the resume triggers an
             # additional set of callbacks, but the self.temp_script_indexes
             # list is empty and the .pop(0) method fails with an IndexError.
-            if data.scriptState == 10:  # FAILED
+            if data.scriptState == ScriptQueue.ScriptState.FAILED:
                 print("Resuming the ScriptQueue after a script FAILED.")
                 await self.remote.cmd_resume.set_start(timeout=10)
 

--- a/python/lsst/ts/IntegrationTests/base_script.py
+++ b/python/lsst/ts/IntegrationTests/base_script.py
@@ -231,7 +231,7 @@ class BaseScript:
             await self.remote.cmd_resume.set_start(timeout=10)
             # Wait for the scripts to complete.
             while not self.all_scripts_done:
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0)
             # Print the script indexes and states.
             print(
                 f"All scripts complete.\n"

--- a/python/lsst/ts/IntegrationTests/base_script.py
+++ b/python/lsst/ts/IntegrationTests/base_script.py
@@ -175,14 +175,17 @@ class BaseScript:
             # Scripts run sequentially and FIFO.
             # When done, remove the leading script.
             self.temp_script_indexes.pop(0)
-            if data.scriptState == 10:  # FAILED
-                # Resume the ScriptQueue, if a script failed,
-                # to continue processing any remaining scripts.
-                print("Resuming the ScriptQueue after a script FAILED.")
-                await self.remote.cmd_resume.set_start(timeout=10)
             # Set the all_scripts_done flag to True when all the
             # scripts are complete.
             self.all_scripts_done = len(self.temp_script_indexes) == 0
+            # Resume the ScriptQueue, if a script failed,
+            # to continue processing any remaining scripts.
+            # NOTE: This MUST be done LAST. Otherwise, the resume triggers an
+            # additional set of callbacks, but the self.temp_script_indexes
+            # list is empty and the .pop(0) method fails with an IndexError.
+            if data.scriptState == 10:  # FAILED
+                print("Resuming the ScriptQueue after a script FAILED.")
+                await self.remote.cmd_resume.set_start(timeout=10)
 
     async def run(self) -> None:
         """Run the specified standard or external scripts.

--- a/python/lsst/ts/IntegrationTests/failing_script_queue_controller.py
+++ b/python/lsst/ts/IntegrationTests/failing_script_queue_controller.py
@@ -20,6 +20,7 @@
 
 import asyncio
 from .script_queue_controller import ScriptQueueController
+from lsst.ts.idl.enums.Script import ScriptState
 from lsst.ts.idl.enums.ScriptQueue import ScriptProcessState
 
 
@@ -74,12 +75,13 @@ class FailingScriptQueueController(ScriptQueueController):
                 await self.evt_script.set_write(
                     scriptSalIndex=script,
                     processState=ScriptProcessState.DONE,
-                    scriptState=10,  # FAILED
+                    scriptState=ScriptState.FAILED,
                     timestampProcessEnd=99999,
                 )
             else:
                 await self.evt_script.set_write(
                     scriptSalIndex=script,
                     processState=ScriptProcessState.DONE,
+                    scriptState=ScriptState.DONE,
                     timestampProcessEnd=99999,
                 )

--- a/python/lsst/ts/IntegrationTests/failing_script_queue_controller.py
+++ b/python/lsst/ts/IntegrationTests/failing_script_queue_controller.py
@@ -19,14 +19,14 @@
 # You should have received a copy of the GNU General Public License
 
 import asyncio
-from lsst.ts import salobj
+from .script_queue_controller import ScriptQueueController
 from lsst.ts.idl.enums.ScriptQueue import ScriptProcessState
 
 
 # Create an inherited class from the controller,
 # so that you can add logic when commands are received.
 # You can also output events and telemetry from there.
-class FailingScriptQueueController(salobj.Controller):
+class FailingScriptQueueController(ScriptQueueController):
     """Define a ScriptQueue controller to use for scripts going into
     failed states. This is used by certain unit tests to
     mimic the functions of the real ScriptQueue, to verify
@@ -34,87 +34,18 @@ class FailingScriptQueueController(salobj.Controller):
     """
 
     def __init__(self, index: int, test_type: str) -> None:
-        """Initialize the ScriptQueue Controller.
+        """Initialize the Failing ScriptQueue Controller.
 
         Parameters
         ----------
         index : `int`
             Defines whether this is a MainTel (index=1)
-        or an AuxTel (index=2) controller.
+            or an AuxTel (index=2) controller.
         test_type : `str`
             Defines what type of failing test to mimic.
         """
-        super().__init__("ScriptQueue", index=index)
-        self.index: int = index
+        super().__init__(index)
         self.test_type: str = test_type
-        self.queue_list: list = []
-        self.cmd_pause.callback = self.do_pause
-        self.cmd_add.callback = self.do_add
-        self.cmd_resume.callback = self.do_resume
-
-    async def pub_hb(self) -> None:
-        """Publish the heartbeat. This ensures the controller is running.
-        The test scripts check for the heartbeat before proceeding.
-
-        """
-        try:
-            while True:
-                await self.evt_heartbeat.write()
-                await asyncio.sleep(1.0)
-        except asyncio.CancelledError:
-            self.log.debug("Heartbeat ended normally")
-        except Exception:
-            self.log.exception("Heartbeat failed!")
-
-    async def start(self) -> None:
-        """Start the Controller and the hertbeat."""
-        await super().start()
-        self.hb_task = asyncio.create_task(self.pub_hb())
-
-    async def do_pause(self, data: tuple) -> None:
-        """Pause the ScriptQueue to add scripts to the queue."""
-        # self.log.info("ScriptQueue paused\n")
-        pass
-
-    async def do_add(self, data: tuple) -> None:
-        """Add scripts to the ScriptQueue queue.
-        This mock function uses a simple array to mimic the queue.
-        It simply appends the script path to the array.
-
-        Parameters
-        ----------
-        data : ``cmd_add.DataType``
-            Data is an object that contains the configuration for the script.
-            This includes the path to the script and the Location in
-            queue.
-
-        """
-        # self.log.info("Script: " + data.path)
-        # self.log.info("Location: " + data.location)
-        self.queue_list.append(data.path)  # type: ignore
-        await self.evt_script.set_write(
-            scriptSalIndex=len(self.queue_list),
-            processState=ScriptProcessState.UNKNOWN,
-            scriptState=0,  # UNKNOWN
-            force_output=True,
-        )
-        await self.evt_script.set_write(
-            scriptSalIndex=len(self.queue_list),
-            processState=ScriptProcessState.LOADING,
-            scriptState=1,  # UNCONFIGURED
-            force_output=True,
-        )
-        await self.evt_script.set_write(
-            scriptSalIndex=len(self.queue_list),
-            processState=ScriptProcessState.CONFIGURED,
-            scriptState=2,  # CONFIGURED
-            force_output=True,
-        )
-        return self.salinfo.make_ackcmd(
-            result=str(len(self.queue_list)),
-            ack=salobj.SalRetCode.CMD_COMPLETE,
-            private_seqNum=1001,
-        )
 
     async def do_resume(self, data: tuple) -> None:
         """Resume the ScriptQueue after adding the scripts
@@ -152,38 +83,3 @@ class FailingScriptQueueController(salobj.Controller):
                     processState=ScriptProcessState.DONE,
                     timestampProcessEnd=99999,
                 )
-
-    async def close_tasks(self) -> None:
-        """This closes the resources for the controller,
-        and terminates the heartbeat loop.
-
-        """
-        self.hb_task.cancel()
-        await super().close_tasks()
-
-    async def do_move(self) -> None:
-        pass
-
-    async def do_requeue(self) -> None:
-        pass
-
-    async def do_showAvailableScripts(self) -> None:
-        pass
-
-    async def do_showQueue(self) -> None:
-        """Show the queue via the output from the queue event."""
-        pass
-
-    async def do_showSchema(self) -> None:
-        pass
-
-    async def do_showScript(self) -> None:
-        pass
-
-    async def do_stopScripts(self) -> None:
-        pass
-
-    @classmethod
-    async def amain(cls, index: int, test_type: str) -> None:
-        csc = cls(index, test_type)
-        await csc.done_task

--- a/python/lsst/ts/IntegrationTests/script_queue_controller.py
+++ b/python/lsst/ts/IntegrationTests/script_queue_controller.py
@@ -40,7 +40,7 @@ class ScriptQueueController(salobj.Controller):
         ----------
         index : `int`
             Defines whether this is a MainTel (index=1)
-        or an AuxTel (index=2) controller.
+            or an AuxTel (index=2) controller.
         """
         super().__init__("ScriptQueue", index=index)
         self.index: int = index

--- a/python/lsst/ts/IntegrationTests/script_queue_controller.py
+++ b/python/lsst/ts/IntegrationTests/script_queue_controller.py
@@ -20,6 +20,7 @@
 
 import asyncio
 from lsst.ts import salobj
+from lsst.ts.idl.enums.Script import ScriptState
 from lsst.ts.idl.enums.ScriptQueue import ScriptProcessState
 
 
@@ -92,19 +93,19 @@ class ScriptQueueController(salobj.Controller):
         await self.evt_script.set_write(
             scriptSalIndex=len(self.queue_list),
             processState=ScriptProcessState.UNKNOWN,
-            scriptState=0,  # UNKNOWN
+            scriptState=ScriptState.UNKNOWN,
             force_output=True,
         )
         await self.evt_script.set_write(
             scriptSalIndex=len(self.queue_list),
             processState=ScriptProcessState.LOADING,
-            scriptState=1,  # UNCONFIGURED
+            scriptState=ScriptState.UNCONFIGURED,
             force_output=True,
         )
         await self.evt_script.set_write(
             scriptSalIndex=len(self.queue_list),
             processState=ScriptProcessState.CONFIGURED,
-            scriptState=2,  # CONFIGURED
+            scriptState=ScriptState.CONFIGURED,
             force_output=True,
         )
         return self.salinfo.make_ackcmd(
@@ -124,13 +125,13 @@ class ScriptQueueController(salobj.Controller):
             await self.evt_script.set_write(
                 scriptSalIndex=script,
                 processState=ScriptProcessState.RUNNING,
-                scriptState=3,  # RUNNING
+                scriptState=ScriptState.RUNNING,
             )
             await asyncio.sleep(0.1)
             await self.evt_script.set_write(
                 scriptSalIndex=script,
                 processState=ScriptProcessState.DONE,
-                scriptState=8,  # DONE
+                scriptState=ScriptState.DONE,
                 timestampProcessEnd=99999,
             )
 

--- a/python/lsst/ts/IntegrationTests/script_queue_controller.py
+++ b/python/lsst/ts/IntegrationTests/script_queue_controller.py
@@ -92,16 +92,19 @@ class ScriptQueueController(salobj.Controller):
         await self.evt_script.set_write(
             scriptSalIndex=len(self.queue_list),
             processState=ScriptProcessState.UNKNOWN,
+            scriptState=0,  # UNKNOWN
             force_output=True,
         )
         await self.evt_script.set_write(
             scriptSalIndex=len(self.queue_list),
             processState=ScriptProcessState.LOADING,
+            scriptState=1,  # UNCONFIGURED
             force_output=True,
         )
         await self.evt_script.set_write(
             scriptSalIndex=len(self.queue_list),
             processState=ScriptProcessState.CONFIGURED,
+            scriptState=2,  # CONFIGURED
             force_output=True,
         )
         return self.salinfo.make_ackcmd(
@@ -119,12 +122,15 @@ class ScriptQueueController(salobj.Controller):
         # self.log.info("ScriptQueue resumed\n")
         for script, _ in enumerate(self.queue_list, start=1):
             await self.evt_script.set_write(
-                scriptSalIndex=script, processState=ScriptProcessState.RUNNING
+                scriptSalIndex=script,
+                processState=ScriptProcessState.RUNNING,
+                scriptState=3,  # RUNNING
             )
             await asyncio.sleep(0.1)
             await self.evt_script.set_write(
                 scriptSalIndex=script,
                 processState=ScriptProcessState.DONE,
+                scriptState=8,  # DONE
                 timestampProcessEnd=99999,
             )
 

--- a/tests/test_auxtel_calibrations.py
+++ b/tests/test_auxtel_calibrations.py
@@ -73,6 +73,8 @@ class AuxTelLatissCalibrationsTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_auxtel_latiss_calibrations_ptc(self) -> None:
         """Execute the AuxTelLatissCalibrations integration test script,
@@ -103,3 +105,5 @@ class AuxTelLatissCalibrationsTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])

--- a/tests/test_auxtel_enable_atcs.py
+++ b/tests/test_auxtel_enable_atcs.py
@@ -43,11 +43,7 @@ class AuxTelEnableATCSTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_auxtel_enable_atcs(self) -> None:
         """Execute the AuxTelEnableATCS integration test script,
-        which runs the ts_standardscripts/auxtel/enable_atcs.py script,
-        followed by the ts_standardscripts/auxtel/enable_atcs.py script.
-        Use the configuration stored in the shutdown_configs.py module;
-        note that only the enable_atcs.py script requires a configuration.
-
+        which runs the ts_standardscripts/auxtel/enable_atcs.py script.
         """
         # Instantiate the AuxTelEnableATCS integration tests.
         script_class = AuxTelEnableATCS()
@@ -58,6 +54,8 @@ class AuxTelEnableATCSTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_housekeeping.py
+++ b/tests/test_auxtel_housekeeping.py
@@ -44,7 +44,6 @@ class AuxTelHousekeepingTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_auxtel_housekeeping(self) -> None:
         """Execute the AuxTelHousekeeping integration test script,
         which runs the ts_standardscripts/run_command.py script.
-
         """
         # Instantiate the AuxTelHousekeeping integration tests.
         script_class = AuxTelHousekeeping()
@@ -55,6 +54,8 @@ class AuxTelHousekeepingTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8, 8, 8, 8, 8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_image_taking_verification.py
+++ b/tests/test_auxtel_image_taking_verification.py
@@ -60,3 +60,5 @@ class RunImageTakingVerificationTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])

--- a/tests/test_auxtel_night_operations.py
+++ b/tests/test_auxtel_night_operations.py
@@ -64,6 +64,8 @@ class AuxTelNightOperationsTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert scripts were added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8, 8, 8])
 
     async def test_auxtel_latiss_cwfs_align(self) -> None:
         """Execute the AuxTelLatissCWFSAlign integration test script,
@@ -85,6 +87,8 @@ class AuxTelNightOperationsTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     @parameterized.expand(["pointing", "verify", "nominal", "test"])
     async def test_auxtel_latiss_acquire_and_take_sequence(self, sequence: str) -> None:
@@ -109,3 +113,5 @@ class AuxTelNightOperationsTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])

--- a/tests/test_auxtel_prepare_for_flat.py
+++ b/tests/test_auxtel_prepare_for_flat.py
@@ -46,7 +46,6 @@ class AuxTelPrepareFlatTestCase(unittest.IsolatedAsyncioTestCase):
         which runs the ts_standardscripts/auxtel/prepare_for_flat.py
         script.
         This test requires no configuration.
-
         """
         # Instantiate the AuxTelPrepareFlat integration tests.
         script_class = AuxTelPrepareFlat()
@@ -57,6 +56,8 @@ class AuxTelPrepareFlatTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_prepare_for_onsky.py
+++ b/tests/test_auxtel_prepare_for_onsky.py
@@ -45,7 +45,6 @@ class AuxTelPrepareOnSkyTestCase(unittest.IsolatedAsyncioTestCase):
         """Execute the AuxTelPrepareOnSky integration test script,
         which runs the ts_standardscripts/auxtel/prepare_for_onsky.py script.
         This test requires no configuration.
-
         """
         # Instantiate the AuxTelPrepareOnSky integration tests.
         script_class = AuxTelPrepareOnSky()
@@ -56,6 +55,8 @@ class AuxTelPrepareOnSkyTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_shutdown.py
+++ b/tests/test_auxtel_shutdown.py
@@ -44,10 +44,6 @@ class AuxTelShutdownTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_auxtel_shutdown(self) -> None:
         """Execute the AuxTelShutdown integration test script,
         which runs the ts_standardscripts/auxtel/shutdown.py script,
-        followed by the ts_standardscripts/auxtel/enable_atcs.py script.
-        Use the configuration stored in the shutdown_configs.py module;
-        note that only the enable_atcs.py script requires a configuration.
-
         """
         # Instantiate the AuxTelShutdown integration tests.
         script_class = AuxTelShutdown()
@@ -58,6 +54,8 @@ class AuxTelShutdownTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_state_transitions.py
+++ b/tests/test_auxtel_state_transitions.py
@@ -59,6 +59,8 @@ class AuxTelStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_auxtel_standby_disabled(self) -> None:
         """Execute the AuxTelStandbyDisabled integration test script,
@@ -76,13 +78,14 @@ class AuxTelStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8])
 
     async def test_auxtel_disabled_enabled(self) -> None:
         """Execute the AuxTelDisabledEnabled integration test script,
         which runs the ts_standardscripts/set_summary_state.py script.
         Use the configuration stored in the at_state_transition_configs.py
         module.
-
         """
         # Instantiate the AuxTelDisabledEnabled integration tests.
         script_class = AuxTelDisabledEnabled()
@@ -93,6 +96,8 @@ class AuxTelStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_stop.py
+++ b/tests/test_auxtel_stop.py
@@ -44,7 +44,6 @@ class AuxTelStopTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_auxtel_stop(self) -> None:
         """Execute the AuxTelStop integration test script,
         which runs the ts_standardscripts/auxtel/stop.py script.
-
         """
         # Instantiate the AuxTelStop integration tests.
         script_class = AuxTelStop()
@@ -55,6 +54,8 @@ class AuxTelStopTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_track_target.py
+++ b/tests/test_auxtel_track_target.py
@@ -45,7 +45,6 @@ class AuxTelTrackTargetTestCase(unittest.IsolatedAsyncioTestCase):
         """Execute the AuxTelTrackTarget integration test script,
         which runs the ts_standardscripts/auxtel/track_target.py script.
         Use the configuration stored in the track_target_configs.py module.
-
         """
         # Mock the command-line argument that the aux_tel_track_target.py
         # script expects.
@@ -65,6 +64,8 @@ class AuxTelTrackTargetTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_auxtel_visit.py
+++ b/tests/test_auxtel_visit.py
@@ -45,7 +45,6 @@ class AuxTelVisitTestCase(unittest.IsolatedAsyncioTestCase):
         """Execute the AuxTelVisit integration test script, which runs the
         ts_standardscripts/auxtel/take_image_latiss.py script.
         Use the configuration stored in the take_image_latiss_configs module.
-
         """
         # Instantiate the AuxTelVisit integration tests.
         script_class = AuxTelVisit()
@@ -56,6 +55,8 @@ class AuxTelVisitTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8, 8, 8, 8, 8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_comcam_calibrations.py
+++ b/tests/test_comcam_calibrations.py
@@ -73,3 +73,5 @@ class ComCamCalibrationsTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])

--- a/tests/test_comcam_image_taking_verification.py
+++ b/tests/test_comcam_image_taking_verification.py
@@ -60,3 +60,5 @@ class RunImageTakingVerificationTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])

--- a/tests/test_eas_state_transitions.py
+++ b/tests/test_eas_state_transitions.py
@@ -58,6 +58,8 @@ class EasStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_eas_disabled_enabled(self) -> None:
         """Execute the EasDisabledEnabled integration test script,
@@ -75,6 +77,8 @@ class EasStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_enabled_offline.py
+++ b/tests/test_enabled_offline.py
@@ -59,6 +59,8 @@ class EnabledOfflineTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8, 8, 8, 8, 8, 8, 8, 8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_failed_script.py
+++ b/tests/test_failed_script.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This file is part of ts_IntegrationTests.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from lsst.ts import salobj
+from lsst.ts.IntegrationTests import FailingScriptQueueController
+from lsst.ts.IntegrationTests import AuxTelHousekeeping
+
+
+class FailedScriptTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test when a script is FAILED."""
+
+    async def asyncSetUp(self) -> None:
+        # Set the LSST_DDS_PARTITION_PREFIX ENV_VAR.
+        salobj.set_random_lsst_dds_partition_prefix()
+
+        # Create the ScriptQueue Controller.
+        self.controller = FailingScriptQueueController(index=2, test_type="FAILED")
+
+        # Start the controller and wait for it be ready.
+        await self.controller.start_task
+
+    async def test_failed_script(self) -> None:
+        """Execute the AuxTelHousekeeping integration test script,
+        but make the final states FAILED.
+        """
+        # Instantiate the AuxTelHousekeeping integration tests.
+        script_class = AuxTelHousekeeping()
+        # Get number of scripts
+        num_scripts = len(script_class.scripts)
+        print(f"AuxTel Housekeeping; running {num_scripts} scripts")
+        # Execute the scripts.
+        await script_class.run()
+        # Assert script was added to ScriptQueue.
+        self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts are FAILED.
+        # When a script is FAILED, it pauses the ScriptQueue and keeps the
+        # failed script in the queue. The integration test script handles this
+        # by sending a resume command to the SQ. By verifying the final script
+        # states, this test ensures the test script doesn't hang and properly
+        # processes through the SQ.
+        self.assertEqual(script_class.script_states, [10, 10, 10, 10, 10, 10])
+
+    async def asyncTearDown(self) -> None:
+        await self.controller.close()
+        await self.controller.done_task

--- a/tests/test_gencam_state_transitions.py
+++ b/tests/test_gencam_state_transitions.py
@@ -58,6 +58,8 @@ class GenCamStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_gencam_disabled_enabled(self) -> None:
         """Execute the GenCamDisabledEnabled integration test script,
@@ -75,6 +77,8 @@ class GenCamStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_load_camera_playlist.py
+++ b/tests/test_load_camera_playlist.py
@@ -80,6 +80,8 @@ class LoadCameraPlaylistTestCase(unittest.IsolatedAsyncioTestCase):
         # Assert script was added to correct ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
         self.assertEqual(script_class.index, 2)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_bad_inputs(self) -> None:
         """Attempt to execute the LoadCameraPlaylist integration test script,
@@ -104,8 +106,7 @@ class LoadCameraPlaylistTestCase(unittest.IsolatedAsyncioTestCase):
         test_camera = "cc"
         test_playlist = "master_flat"
         test_no_repeat = False
-        # Instantiate the LoadCameraPlaylist integration tests object and
-        # execute the scripts.
+        # Instantiate the LoadCameraPlaylist integration tests object.
         script_class = LoadCameraPlaylist(
             camera=test_camera, playlist_shortname=test_playlist, repeat=test_no_repeat
         )

--- a/tests/test_love_stress.py
+++ b/tests/test_love_stress.py
@@ -56,6 +56,8 @@ class LoveStressTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_maintel_housekeeping.py
+++ b/tests/test_maintel_housekeeping.py
@@ -55,6 +55,8 @@ class MainTelHousekeepingTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_maintel_state_transitions.py
+++ b/tests/test_maintel_state_transitions.py
@@ -59,6 +59,8 @@ class MainTelStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_maintel_standby_disabled(self) -> None:
         """Execute the MainTelStandbyDisabled integration test script,
@@ -76,6 +78,8 @@ class MainTelStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8])
 
     async def test_maintel_disabled_enabled(self) -> None:
         """Execute the MainTelDisabledEnabled integration test script,
@@ -93,6 +97,8 @@ class MainTelStateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8, 8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_obssys2_state_transitions.py
+++ b/tests/test_obssys2_state_transitions.py
@@ -58,6 +58,8 @@ class ObsSys2StateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def test_obssys2_disabled_enabled(self) -> None:
         """Execute the ObsSys2DisabledEnabled integration test script,
@@ -75,6 +77,8 @@ class ObsSys2StateTransitionTestCase(unittest.IsolatedAsyncioTestCase):
         await script_class.run()
         # Assert script was added to ScriptQueue.
         self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert scripts passed.
+        self.assertEqual(script_class.script_states, [8])
 
     async def asyncTearDown(self) -> None:
         await self.controller.close()

--- a/tests/test_terminated_script.py
+++ b/tests/test_terminated_script.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This file is part of ts_IntegrationTests.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from lsst.ts import salobj
+from lsst.ts.IntegrationTests import FailingScriptQueueController
+from lsst.ts.IntegrationTests import AuxTelHousekeeping
+
+
+class TerminatedScriptTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test when a script is TERMINATED."""
+
+    async def asyncSetUp(self) -> None:
+        # Set the LSST_DDS_PARTITION_PREFIX ENV_VAR.
+        salobj.set_random_lsst_dds_partition_prefix()
+
+        # Create the ScriptQueue Controller.
+        self.controller = FailingScriptQueueController(index=2, test_type="TERMINATED")
+
+        # Start the controller and wait for it be ready.
+        await self.controller.start_task
+
+    async def test_failed_script(self) -> None:
+        """Execute the AuxTelHousekeeping integration test script,
+        but make the final state TERMINATED.
+        """
+        # Instantiate the AuxTelHousekeeping integration tests.
+        script_class = AuxTelHousekeeping()
+        # Get number of scripts
+        num_scripts = len(script_class.scripts)
+        print(f"AuxTel Houskeeping; running {num_scripts} scripts")
+        # Execute the scripts.
+        await script_class.run()
+        # Assert script was added to ScriptQueue.
+        self.assertEqual(len(self.controller.queue_list), num_scripts)
+        # Assert script TERMINATED.
+        # Since TERMINATED is an acceptable terminal script state,
+        # this test mainly concerns verifying the integration test
+        # properly handles this state and doesn't hang indefinitely.
+        self.assertEqual(script_class.script_states, [7, 7, 7, 7, 7, 7])
+
+    async def asyncTearDown(self) -> None:
+        await self.controller.close()
+        await self.controller.done_task


### PR DESCRIPTION
* Re-implement the Script.ScriptState enums for final script status.
* Added missing documentation.
* Added unit tests for failing (FAILED and TERMINATED) scripts.
* Added checks for scripts passing to previous unit tests.