### PR TITLE
Tickets/dm44155: Fixed empty-config definition

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -14,6 +14,8 @@ v0.28.0
 -------
 * Removed MainTel Camera state transition scripts and configs.
 * Add MTRotator to ignore list in enabled_offline_state_transition_configs.py.
+* Moved the callback definition in base_script.py.
+* Fixed an empty-config definition.
 
 v0.27.0
 -------

--- a/python/lsst/ts/IntegrationTests/auxtel_housekeeping.py
+++ b/python/lsst/ts/IntegrationTests/auxtel_housekeeping.py
@@ -38,7 +38,7 @@ class AuxTelHousekeeping(BaseScript):
 
     index: int = 2
     configs: tuple = (
-        [],
+        "",
         registry["atdome_home"],
         registry["atdome_park"],
         registry["atptg_park"],

--- a/python/lsst/ts/IntegrationTests/base_script.py
+++ b/python/lsst/ts/IntegrationTests/base_script.py
@@ -184,9 +184,6 @@ class BaseScript:
             # Since `async with` is used,
             # you do NOT have to wait for the remote to start
 
-            # Create the callback to the ScriptQueue Script Event that
-            # will wait for all the scripts to complete.
-            self.remote.evt_script.callback = self.wait_for_done
             # Convert the queue_placement parameter to the approprirate
             # ScriptQueue.Location Enum object.
             queue_placement = getattr(Location, self.queue_placement.upper())
@@ -213,6 +210,9 @@ class BaseScript:
             # Copy the script_indexes list to use in the Script Event callback.
             # This maintains the integrity of the real script_indexes list.
             self.temp_script_indexes = copy.deepcopy(script_indexes)
+            # Create the callback to the ScriptQueue Script Event that
+            # will wait for all the scripts to complete.
+            self.remote.evt_script.callback = self.wait_for_done
             # Resume the ScriptQueue to begin script execution.
             await self.remote.cmd_resume.set_start(timeout=10)
             # Wait for the scripts to complete.


### PR DESCRIPTION
* Moved a callback definition to a later point, since it was referencing a variable created after it.